### PR TITLE
Added a table output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/italolelis/reachable
 
 require (
+	github.com/apcera/termtables v0.0.0-20170405184538-bcbc5dc54055
 	github.com/apex/log v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gojektech/heimdall v5.0.0+incompatible
 	github.com/gojektech/valkyrie v0.0.0-20180524055739-b19510f6c63c // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mattn/go-runewidth v0.0.3 // indirect
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/InVisionApp/tabular v0.3.0 h1:4DGJoBZRTcgd/O+YgfG7/9bXAQy01tSJxrxWEuHVgnM=
+github.com/InVisionApp/tabular v0.3.0/go.mod h1:/G6t7qe0ZULisB+FjMsB0Qu0mtJ2CZldq92nXWjfHGI=
+github.com/apcera/termtables v0.0.0-20170405184538-bcbc5dc54055 h1:IkPAzP+QjchKXXFX6LCcpDKa89b/e/0gPCUbQGWtUUY=
+github.com/apcera/termtables v0.0.0-20170405184538-bcbc5dc54055/go.mod h1:8mHYHlOef9UC51cK1/WRvE/iQVM8O8QlYFa8eh8r5I8=
 github.com/apex/log v1.0.0 h1:5UWeZC54mWVtOGSCjtuvDPgY/o0QxmjQgvYZ27pLVGQ=
 github.com/apex/log v1.0.0/go.mod h1:yA770aXIDQrhVOIGurT/pVdfCpSq1GQV/auzMN5fzvY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -8,6 +12,8 @@ github.com/gojektech/valkyrie v0.0.0-20180524055739-b19510f6c63c h1:muIXCSMlpYUO
 github.com/gojektech/valkyrie v0.0.0-20180524055739-b19510f6c63c/go.mod h1:tDYRk1s5Pms6XJjj5m2PxAzmQvaDU8GqDf1u6x7yxKw=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Instead of giving an output to stdout only I've added a table output when in `verbose` mode.

```
❯ go run main.go check google.com twitter.com not-valid-blah.com -v
   ⨯ Get http://not-valid-blah.com: dial tcp: lookup not-valid-blah.com: no such host
   ⨯ Unreachable!              domain=not-valid-blah.com
   • Reachable!                domain=twitter.com
   • Reachable!                domain=google.com
+-------------+-------------+------------+----------------+---------------+-------------------+------------------+---------------+
| Domain      | Status Code | DNS Lookup | TCP Connection | TLS Handshake | Server Processing | Content Transfer | Total Time    |
+-------------+-------------+------------+----------------+---------------+-------------------+------------------+---------------+
| twitter.com | 200         | 1          | 20             | 240           | 173               | 2562047          | 9223372036854 |
| google.com  | 200         | 1          | 31             | 0             | 87                | 2562047          | 9223372036854 |
+-------------+-------------+------------+----------------+---------------+-------------------+------------------+---------------+
```